### PR TITLE
Fix AssertionError when sending iBSS

### DIFF
--- a/dfuexec.py
+++ b/dfuexec.py
@@ -269,7 +269,7 @@ class PwnedDFUDevice():
     def flash_nor(self, nor):
         self.boot_ibss()
         print 'Sending iBSS payload to flash NOR.'
-        MAX_SHELLCODE_LENGTH = 128
+        MAX_SHELLCODE_LENGTH = 132
         payload = open('bin/ibss-flash-nor-shellcode.bin', 'rb').read()
         assert len(payload) <= MAX_SHELLCODE_LENGTH
         payload += '\x00' * (MAX_SHELLCODE_LENGTH - len(payload)) + nor


### PR DESCRIPTION
Changed MAX_SHELLCODE_LENGTH = 128 to MAX_SHELLCODE_LENGTH = 132 since the iBSS payload is now 132 bytes instead of 128 bytes.