### PR TITLE
Use python interpreter from environment

### DIFF
--- a/ibootpatcher
+++ b/ibootpatcher
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # ibootpatcher: patch assembly code in iBoot binaries
 # Author: axi0mX
 

--- a/ipwndfu
+++ b/ipwndfu
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # ipwndfu: open-source jailbreaking tool for older iOS devices
 # Author: axi0mX
 

--- a/ipwnrecovery
+++ b/ipwnrecovery
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # ipwnrecovery: open-source jailbreaking tool for older iOS devices
 # Author: axi0mX
 


### PR DESCRIPTION
We cannot rely on the python binary being present at `/usr/bin/python`.
Nix or virtualenv modify $PATH instead of adding python to `/usr/bin/`.