### PR TITLE
Supports simultaneous operation of multiple devices by matching ECIDs

### DIFF
--- a/dfu.py
+++ b/dfu.py
@@ -5,6 +5,12 @@ import libusbfinder
 
 MAX_PACKET_SIZE = 0x800
 
+DEVICE_ECID_MATCH=None
+
+def set_device_ecid(ecid):
+    global DEVICE_ECID_MATCH
+    DEVICE_ECID_MATCH = ecid
+
 def acquire_device(timeout=5.0, match=None, fatal=True):
   backend = usb.backend.libusb1.get_backend(find_library=lambda x:libusbfinder.libusb1_path())
   #print 'Acquiring device handle.'
@@ -15,6 +21,8 @@ def acquire_device(timeout=5.0, match=None, fatal=True):
       once = True
       for device in usb.core.find(find_all=True, idVendor=0x5AC, idProduct=0x1227, backend=backend):
           if match is not None and match not in device.serial_number:
+              continue
+          if DEVICE_ECID_MATCH is not None and DEVICE_ECID_MATCH not in device.serial_number:
               continue
           return device
       time.sleep(0.001)

--- a/ipwndfu
+++ b/ipwndfu
@@ -33,7 +33,7 @@ def print_help():
 
 if __name__ == '__main__':
     try:
-        advanced = ['ecid', 'demote', 'boot', 'dump=', 'hexdump=', 'dump-rom', 'dump-nor=', 'flash-nor=', '24kpwn', 'remove-24kpwn', 'remove-alloc8', 'decrypt-gid=', 'encrypt-gid=', 'decrypt-uid=', 'encrypt-uid=']
+        advanced = ['ecid=', 'demote', 'boot', 'dump=', 'hexdump=', 'dump-rom', 'dump-nor=', 'flash-nor=', '24kpwn', 'remove-24kpwn', 'remove-alloc8', 'decrypt-gid=', 'encrypt-gid=', 'decrypt-uid=', 'encrypt-uid=']
         opts, args = getopt.getopt(sys.argv[1:], 'pxf:', advanced)
     except getopt.GetoptError:
         print 'ERROR: Invalid arguments provided.'
@@ -126,7 +126,7 @@ if __name__ == '__main__':
             dfu.release_device(device)
 
         if opt == '--ecid':
-            ecid = '{:016X}'.format(arg)
+            ecid = '%016X' % int(arg)
             dfu.set_device_ecid(arg)
             print 'Match only devices with ECID: ' , ecid
 

--- a/ipwndfu
+++ b/ipwndfu
@@ -127,7 +127,7 @@ if __name__ == '__main__':
 
         if opt == '--ecid':
             ecid = '%016X' % int(arg)
-            dfu.set_device_ecid(arg)
+            dfu.set_device_ecid(ecid)
             print 'Match only devices with ECID: ' , ecid
 
         if opt == '--demote':

--- a/ipwndfu
+++ b/ipwndfu
@@ -15,6 +15,7 @@ def print_help():
     print '  -x\t\t\t\tinstall alloc8 exploit to NOR'
     print '  -f file\t\t\tsend file to device in DFU Mode'
     print 'Advanced options:'
+    print '  --ecid\t\t\tspecify the device to match'
     print '  --demote\t\t\tdemote device to enable JTAG'
     print '  --boot\t\t\tboot device'
     print '  --dump=address,length\t\tdump memory to stdout'
@@ -32,7 +33,7 @@ def print_help():
 
 if __name__ == '__main__':
     try:
-        advanced = ['demote', 'boot', 'dump=', 'hexdump=', 'dump-rom', 'dump-nor=', 'flash-nor=', '24kpwn', 'remove-24kpwn', 'remove-alloc8', 'decrypt-gid=', 'encrypt-gid=', 'decrypt-uid=', 'encrypt-uid=']
+        advanced = ['ecid', 'demote', 'boot', 'dump=', 'hexdump=', 'dump-rom', 'dump-nor=', 'flash-nor=', '24kpwn', 'remove-24kpwn', 'remove-alloc8', 'decrypt-gid=', 'encrypt-gid=', 'decrypt-uid=', 'encrypt-uid=']
         opts, args = getopt.getopt(sys.argv[1:], 'pxf:', advanced)
     except getopt.GetoptError:
         print 'ERROR: Invalid arguments provided.'
@@ -123,6 +124,11 @@ if __name__ == '__main__':
             dfu.send_data(device, data)
             dfu.request_image_validation(device)
             dfu.release_device(device)
+
+        if opt == '--ecid':
+            ecid = '{:016X}'.format(arg)
+            dfu.set_device_ecid(arg)
+            print 'Match only devices with ECID: ' , ecid
 
         if opt == '--demote':
             device = dfu.acquire_device()


### PR DESCRIPTION
There is an ECID HEX value in the serial number returned by DFU and Recovery.
So we pass in an integer, convert it to Hex and match the serial number.
Returns the device if it exists.

This operation allows the user to perform multiple operations at the same time.